### PR TITLE
feat : auto-generate manifest.json by CI

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -28,7 +28,8 @@ jobs:
         run: dotnet build --configuration Release
         
       - name: Generate manifest.json
-        run: dotnet run --project Translator -- generate-manifest
+        run: dotnet run -- generate-manifest
+        working-directory: Translator
         
       - name: Commit
         uses: EndBug/add-and-commit@v10

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -5,7 +5,13 @@ on:
     branches: [ main ]
     paths:
       - 'Translator/translations/**.json'
-    
+  # Manual re-run path. The generator is fail-fast: a single broken
+  # translation file (missing language mapping, invalid JSON, unreadable
+  # hash) aborts the whole run and the auto-trigger does not retry.
+  # Fix the offending file, then dispatch this workflow manually from
+  # the Actions tab to refresh the manifest.
+  workflow_dispatch:
+
 permissions:
   contents: write
   

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -4,12 +4,7 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'Translator/translations/**.json'
-  # Manual re-run path. The generator is fail-fast: a single broken
-  # translation file (missing language mapping, invalid JSON, unreadable
-  # hash) aborts the whole run and the auto-trigger does not retry.
-  # Fix the offending file, then dispatch this workflow manually from
-  # the Actions tab to refresh the manifest.
+      - 'Translator/translations/**/*.json'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -1,0 +1,40 @@
+﻿name: Generate Manifest
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'Translator/translations/**.json'
+    
+permissions:
+  contents: write
+  
+jobs:
+  manifest-generation:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build solution
+        run: dotnet build --configuration Release
+        
+      - name: Generate manifest.json
+        run: dotnet run --project Translator -- generate-manifest
+        
+      - name: Commit
+        uses: EndBug/add-and-commit@v10
+        with:
+          default_author: github_actor
+          add: ./manifest.json # if the working directory is the repo root dir
+          message: "Update manifest.json"
+          commit: ""
+          push: true

--- a/Translator.Tests/CliTestHost.cs
+++ b/Translator.Tests/CliTestHost.cs
@@ -62,7 +62,7 @@ internal static class CliTestHost
             catch (InvalidOperationException) { /* already exited */ }
             catch (System.ComponentModel.Win32Exception) { /* exiting / access denied */ }
 
-            await Task.WhenAny(Task.WhenAll(stdOutTask, stdErrTask), Task.Delay(2000));
+            await Task.WhenAny(Task.WhenAll(stdOutTask, stdErrTask), Task.Delay(2000, cts.Token));
             var partialOut = stdOutTask.IsCompletedSuccessfully ? stdOutTask.Result : string.Empty;
             var partialErr = stdErrTask.IsCompletedSuccessfully ? stdErrTask.Result : string.Empty;
             throw new TimeoutException(

--- a/Translator.Tests/CliTestHost.cs
+++ b/Translator.Tests/CliTestHost.cs
@@ -62,7 +62,7 @@ internal static class CliTestHost
             catch (InvalidOperationException) { /* already exited */ }
             catch (System.ComponentModel.Win32Exception) { /* exiting / access denied */ }
 
-            await Task.WhenAny(Task.WhenAll(stdOutTask, stdErrTask), Task.Delay(2000, cts.Token));
+            await Task.WhenAny(Task.WhenAll(stdOutTask, stdErrTask), Task.Delay(2000));
             var partialOut = stdOutTask.IsCompletedSuccessfully ? stdOutTask.Result : string.Empty;
             var partialErr = stdErrTask.IsCompletedSuccessfully ? stdErrTask.Result : string.Empty;
             throw new TimeoutException(

--- a/Translator.Tests/Services/ManifestGeneratorTests.cs
+++ b/Translator.Tests/Services/ManifestGeneratorTests.cs
@@ -1,0 +1,315 @@
+﻿using System.Security.Cryptography;
+using System.Text.Json;
+using BTCPayTranslator.Models;
+using BTCPayTranslator.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BTCPayTranslator.Tests.Services;
+
+public class ManifestGeneratorTests
+{
+    [Fact]
+    public async Task GenerateManifest_WritesManifest_ForValidTranslationFile()
+    {
+        var tempDir = CreateTempDirectory();
+        var translationsDir = Path.Combine(tempDir, "translations");
+        Directory.CreateDirectory(translationsDir);
+        var translationFile = Path.Combine(translationsDir, "French.json");
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(translationFile, """
+                {
+                  "_maintainer": "alice|https://github.com/alice",
+                  "hello": "bonjour"
+                }
+                """);
+
+            var sut = CreateSut();
+            var result = await sut.GenerateManifest(translationsDir, manifestPath);
+
+            Assert.True(result);
+            Assert.True(File.Exists(manifestPath));
+
+            var manifest = await ReadManifest(manifestPath);
+            var entry = Assert.Single(manifest.Languages);
+
+            Assert.Equal("fr", entry.Code);
+            Assert.Equal("fr-FR", entry.Bcp47);
+            Assert.Equal("French", entry.Name);
+            Assert.Equal("Français", entry.Native);
+            Assert.Equal("translations/French.json", entry.File);
+            Assert.Equal("alice|https://github.com/alice", entry.Maintainer);
+            Assert.Equal(ComputeSha256(translationFile), entry.Sha);
+            Assert.Matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$", entry.Updated);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GenerateManifest_ReturnsFalse_WhenNoTranslationFilesExist()
+    {
+        var tempDir = CreateTempDirectory();
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            var sut = CreateSut();
+
+            var result = await sut.GenerateManifest(tempDir, manifestPath);
+
+            Assert.False(result);
+            Assert.False(File.Exists(manifestPath));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GenerateManifest_ReturnsFalse_WhenTranslationDirectoryDoesNotExist()
+    {
+        var translationsDir = Path.Combine(Path.GetTempPath(), "BTCPayTranslator.Tests", Guid.NewGuid().ToString("N"));
+        var manifestPath = Path.Combine(Path.GetTempPath(), "BTCPayTranslator.Tests", Guid.NewGuid().ToString("N"), "manifest.json");
+        var sut = CreateSut();
+
+        var result = await sut.GenerateManifest(translationsDir, manifestPath);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GenerateManifest_RetainsUpdated_WhenExistingShaMatches()
+    {
+        var tempDir = CreateTempDirectory();
+        var translationsDir = Path.Combine(tempDir, "translations");
+        Directory.CreateDirectory(translationsDir);
+        var translationFile = Path.Combine(translationsDir, "French.json");
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(translationFile, """
+                {
+                  "_maintainer": "alice|https://github.com/alice",
+                  "hello": "bonjour"
+                }
+                """);
+
+            var existingSha = ComputeSha256(translationFile);
+            var expectedUpdated = "2024-01-02T03:04:05Z";
+            var existingManifest = new Manifest(
+                new List<ManifestEntry>
+                {
+                    new(
+                        Code: "fr",
+                        Bcp47: "fr-FR",
+                        Name: "French",
+                        Native: "Français",
+                        File: "translations/French.json",
+                        Sha: existingSha,
+                        Maintainer: "old",
+                        Updated: expectedUpdated)
+                },
+                Redirect: null);
+
+            await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(existingManifest));
+
+            var sut = CreateSut();
+            var result = await sut.GenerateManifest(translationsDir, manifestPath);
+
+            Assert.True(result);
+            var generated = await ReadManifest(manifestPath);
+            var entry = Assert.Single(generated.Languages);
+            Assert.Equal(expectedUpdated, entry.Updated);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GenerateManifest_UpdatesUpdated_WhenExistingShaDiffers()
+    {
+        var tempDir = CreateTempDirectory();
+        var translationsDir = Path.Combine(tempDir, "translations");
+        Directory.CreateDirectory(translationsDir);
+        var translationFile = Path.Combine(translationsDir, "French.json");
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(translationFile, """
+                {
+                  "_maintainer": "alice|https://github.com/alice",
+                  "hello": "bonjour"
+                }
+                """);
+
+            var previousUpdated = "2024-01-02T03:04:05Z";
+            var existingManifest = new Manifest(
+                new List<ManifestEntry>
+                {
+                    new(
+                        Code: "fr",
+                        Bcp47: "fr-FR",
+                        Name: "French",
+                        Native: "Français",
+                        File: "translations/French.json",
+                        Sha: "deadbeef",
+                        Maintainer: "old",
+                        Updated: previousUpdated)
+                },
+                Redirect: null);
+
+            await File.WriteAllTextAsync(manifestPath, JsonSerializer.Serialize(existingManifest));
+
+            var sut = CreateSut();
+            var result = await sut.GenerateManifest(translationsDir, manifestPath);
+
+            Assert.True(result);
+            var generated = await ReadManifest(manifestPath);
+            var entry = Assert.Single(generated.Languages);
+
+            Assert.NotEqual(previousUpdated, entry.Updated);
+            Assert.Matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$", entry.Updated);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GenerateManifest_SetsMaintainerToNull_WhenFieldMissing()
+    {
+        var tempDir = CreateTempDirectory();
+        var translationFile = Path.Combine(tempDir, "French.json");
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(translationFile, """
+                {
+                  "hello": "bonjour"
+                }
+                """);
+
+            var sut = CreateSut();
+            var result = await sut.GenerateManifest(tempDir, manifestPath);
+
+            Assert.True(result);
+            var manifest = await ReadManifest(manifestPath);
+            var entry = Assert.Single(manifest.Languages);
+            Assert.Null(entry.Maintainer);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GenerateManifest_ReturnsFalse_WhenLanguageNameMappingIsMissing()
+    {
+        var tempDir = CreateTempDirectory();
+        var translationFile = Path.Combine(tempDir, "Klingon.json");
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(translationFile, """
+                {
+                  "_maintainer": "alice|https://github.com/alice",
+                  "hello": "nuqneH"
+                }
+                """);
+
+            var sut = CreateSut();
+            var result = await sut.GenerateManifest(tempDir, manifestPath);
+
+            Assert.False(result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GenerateManifest_ReturnsFalse_WhenTranslationFileHasInvalidJson()
+    {
+        var tempDir = CreateTempDirectory();
+        var translationFile = Path.Combine(tempDir, "French.json");
+        var manifestPath = Path.Combine(tempDir, "manifest.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(translationFile, "{\"_maintainer\":");
+
+            var sut = CreateSut();
+            var result = await sut.GenerateManifest(tempDir, manifestPath);
+
+            Assert.False(result);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    private static ManifestGenerator CreateSut()
+    {
+        return new ManifestGenerator(NullLogger<ManifestGenerator>.Instance);
+    }
+
+    private static async Task<Manifest> ReadManifest(string path)
+    {
+        var json = await File.ReadAllTextAsync(path);
+        var manifest = JsonSerializer.Deserialize<Manifest>(json);
+        return Assert.IsType<Manifest>(manifest);
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var sha256 = SHA256.Create();
+        using var stream = File.OpenRead(path);
+        var hash = sha256.ComputeHash(stream);
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "BTCPayTranslator.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/Translator/Models/LanguageInfo.cs
+++ b/Translator/Models/LanguageInfo.cs
@@ -122,44 +122,13 @@ public static class SupportedLanguages
         return Languages.Values;
     }
 
-    // Explicit translation-file-basename -> language-code mapping. The keys are
-    // the lowercased basenames as they appear under Translator/translations/
-    // (e.g. `french.json` -> "french"), the values index into Languages above.
-    //
-    // This is the durable contract for the manifest generator: when a new
-    // translation file lands, its row must be added here. That's intentional -
-    // LanguageInfo.Name cannot uniquely resolve cases like "portuguese.json"
-    // (Brazil vs European - Languages key "pt" -> Name "Portuguese (Brazil)"),
-    // so an implicit name-based lookup would silently drop or mis-route
-    // entries. Keep this map small and explicit.
-    public static readonly IReadOnlyDictionary<string, string> FileNameToCode =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["dutch"] = "nl",
-            ["french"] = "fr",
-            ["german"] = "de",
-            ["hindi"] = "hi",
-            ["indonesian"] = "id",
-            ["italian"] = "it",
-            ["japanese"] = "ja",
-            ["korean"] = "ko",
-            ["norwegian"] = "no",
-            ["portuguese"] = "pt",
-            ["russian"] = "ru",
-            ["serbian"] = "sr",
-            ["spanish"] = "es",
-            ["thai"] = "th",
-            ["turkish"] = "tr"
-        };
-
-    public static (string Code, LanguageInfo)? GetLanguageInfoByFileName(string fileName)
+    public static (string Code, LanguageInfo)? GetLanguageInfoByName(string name)
     {
-        if (string.IsNullOrWhiteSpace(fileName))
-            return null;
-        if (!FileNameToCode.TryGetValue(fileName, out var code))
-            return null;
-        if (!Languages.TryGetValue(code, out var info))
-            return null;
-        return (code, info);
+        var match = Languages.FirstOrDefault(kvp =>
+            kvp.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        if (match.Key == null) return null;
+        
+        return (match.Key, match.Value);
     }
 }

--- a/Translator/Models/LanguageInfo.cs
+++ b/Translator/Models/LanguageInfo.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BTCPayTranslator.Models;
 
@@ -118,5 +120,16 @@ public static class SupportedLanguages
     public static IEnumerable<LanguageInfo> GetAllLanguages()
     {
         return Languages.Values;
+    }
+
+    public static (string Code, LanguageInfo)? GetLanguageInfoByName(string name)
+    {
+        var match = Languages.FirstOrDefault(kvp =>
+            kvp.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+
+        if (match.Key is null)
+            return null;
+
+        return (match.Key, match.Value);
     }
 }

--- a/Translator/Models/LanguageInfo.cs
+++ b/Translator/Models/LanguageInfo.cs
@@ -122,14 +122,44 @@ public static class SupportedLanguages
         return Languages.Values;
     }
 
-    public static (string Code, LanguageInfo)? GetLanguageInfoByName(string name)
+    // Explicit translation-file-basename -> language-code mapping. The keys are
+    // the lowercased basenames as they appear under Translator/translations/
+    // (e.g. `french.json` -> "french"), the values index into Languages above.
+    //
+    // This is the durable contract for the manifest generator: when a new
+    // translation file lands, its row must be added here. That's intentional -
+    // LanguageInfo.Name cannot uniquely resolve cases like "portuguese.json"
+    // (Brazil vs European - Languages key "pt" -> Name "Portuguese (Brazil)"),
+    // so an implicit name-based lookup would silently drop or mis-route
+    // entries. Keep this map small and explicit.
+    public static readonly IReadOnlyDictionary<string, string> FileNameToCode =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["dutch"] = "nl",
+            ["french"] = "fr",
+            ["german"] = "de",
+            ["hindi"] = "hi",
+            ["indonesian"] = "id",
+            ["italian"] = "it",
+            ["japanese"] = "ja",
+            ["korean"] = "ko",
+            ["norwegian"] = "no",
+            ["portuguese"] = "pt",
+            ["russian"] = "ru",
+            ["serbian"] = "sr",
+            ["spanish"] = "es",
+            ["thai"] = "th",
+            ["turkish"] = "tr"
+        };
+
+    public static (string Code, LanguageInfo)? GetLanguageInfoByFileName(string fileName)
     {
-        var match = Languages.FirstOrDefault(kvp =>
-            kvp.Value.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-
-        if (match.Key is null)
+        if (string.IsNullOrWhiteSpace(fileName))
             return null;
-
-        return (match.Key, match.Value);
+        if (!FileNameToCode.TryGetValue(fileName, out var code))
+            return null;
+        if (!Languages.TryGetValue(code, out var info))
+            return null;
+        return (code, info);
     }
 }

--- a/Translator/Models/ManifestEntry.cs
+++ b/Translator/Models/ManifestEntry.cs
@@ -11,7 +11,7 @@ public record ManifestEntry(
     string File, // "translations/french.json"
     string Sha, // "abc123..."
     string? Maintainer, // "teamssUTXO|https://github.com/teamssUTXO"
-    DateTime Updated // 2026-04-12T10:30:00Z
+    string Updated // 2026-04-12T10:30:00Z
 );
 
 public record Manifest(

--- a/Translator/Models/ManifestEntry.cs
+++ b/Translator/Models/ManifestEntry.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace BTCPayTranslator.Models;
+
+public record ManifestEntry(
+    string Code, // "fr"
+    string Bcp47, // "fr-FR"
+    string Name, // "French"
+    string Native, // "Français"
+    string File, // "translations/french.json"
+    string Sha, // "abc123..."
+    string? Maintainer, // "teamssUTXO|https://github.com/teamssUTXO"
+    DateTime Updated // 2026-04-12T10:30:00Z
+);
+
+public record Manifest(
+    List<ManifestEntry> Languages,
+    string? Redirect
+);

--- a/Translator/Program.cs
+++ b/Translator/Program.cs
@@ -47,7 +47,8 @@ class Program
             CreateUpdateCommand(serviceProvider),
             CreateBatchUpdateCommand(serviceProvider),
             CreateUpdateAllCommand(serviceProvider),
-            CreateValidatePacksCommand(serviceProvider)
+            CreateValidatePacksCommand(serviceProvider),
+            CreateManifest(serviceProvider)
         };
 
         return await rootCommand.InvokeAsync(args);
@@ -69,6 +70,8 @@ class Program
         services.AddTransient<LanguagePackValidator>();
 
         services.AddTransient<ITranslationService, BaseTranslationService>();
+
+        services.AddTransient<ManifestGenerator>();
     }
 
     private static Option<string?> CreateBTCPayUrlOption() =>
@@ -492,6 +495,52 @@ class Program
             }
         }, fixOption);
 
+        return command;
+    }
+    
+    private static Command CreateManifest(ServiceProvider serviceProvider)
+    {
+        var translationPathOption = new Option<string>(
+            "--translation-path",
+            "Path to the translations folder")
+        {
+            IsRequired = false
+        };
+        translationPathOption.SetDefaultValue("./translations");
+        
+        var manifestPathOption = new Option<string>(
+            "--manifest-path",
+            "Path where manifest.json will be written")
+        {
+            IsRequired = false
+        };
+        manifestPathOption.SetDefaultValue("../manifest.json");
+
+        var command = new Command("generate-manifest", "Generate the manifest.json from translation files")
+        {
+            translationPathOption,
+            manifestPathOption,
+        };
+        
+        command.SetHandler(async (translationPath, manifestPath) =>
+        {
+            using var scope = serviceProvider.CreateScope();
+            var generator = scope.ServiceProvider.GetRequiredService<ManifestGenerator>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            
+            logger.LogInformation("Starting manifest generation...");
+            
+            var success = await generator.GenerateManifest(translationPath, manifestPath);
+
+            if (!success)
+            {
+                logger.LogError("Failed to generate manifest");
+                Environment.Exit(1);
+            }
+            
+            logger.LogInformation("Manifest generated successfully at {manifestPath}", manifestPath);
+        }, translationPathOption, manifestPathOption);
+        
         return command;
     }
 

--- a/Translator/Program.cs
+++ b/Translator/Program.cs
@@ -48,7 +48,7 @@ class Program
             CreateBatchUpdateCommand(serviceProvider),
             CreateUpdateAllCommand(serviceProvider),
             CreateValidatePacksCommand(serviceProvider),
-            CreateManifest(serviceProvider)
+            CreateGenerateManifestCommand(serviceProvider)
         };
 
         return await rootCommand.InvokeAsync(args);
@@ -498,38 +498,49 @@ class Program
         return command;
     }
     
-    private static Command CreateManifest(ServiceProvider serviceProvider)
+    private static Command CreateGenerateManifestCommand(ServiceProvider serviceProvider)
     {
+        // Anchor default paths to the Translator project directory rather than to
+        // the caller's cwd. The generator should produce the same manifest whether
+        // a contributor runs `dotnet run --project Translator` from the repo root,
+        // from inside Translator/, or via the `manifest.yml` workflow with its
+        // explicit `working-directory: Translator`. Walk up from
+        // AppContext.BaseDirectory looking for BTCPayTranslator.csproj; the
+        // containing directory is the project root.
+        var projectDirectory = ResolveProjectDirectory();
+        var defaultTranslationPath = Path.Combine(projectDirectory, "translations");
+        var defaultManifestPath = Path.Combine(projectDirectory, "..", "manifest.json");
+
         var translationPathOption = new Option<string>(
             "--translation-path",
-            "Path to the translations folder")
+            "Path to the translations folder. Defaults to <project-dir>/translations.")
         {
             IsRequired = false
         };
-        translationPathOption.SetDefaultValue("./translations");
-        
+        translationPathOption.SetDefaultValue(defaultTranslationPath);
+
         var manifestPathOption = new Option<string>(
             "--manifest-path",
-            "Path where manifest.json will be written")
+            "Path where manifest.json will be written. Defaults to <repo-root>/manifest.json.")
         {
             IsRequired = false
         };
-        manifestPathOption.SetDefaultValue("../manifest.json");
+        manifestPathOption.SetDefaultValue(defaultManifestPath);
 
         var command = new Command("generate-manifest", "Generate the manifest.json from translation files")
         {
             translationPathOption,
             manifestPathOption,
         };
-        
+
         command.SetHandler(async (translationPath, manifestPath) =>
         {
             using var scope = serviceProvider.CreateScope();
             var generator = scope.ServiceProvider.GetRequiredService<ManifestGenerator>();
             var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-            
+
             logger.LogInformation("Starting manifest generation...");
-            
+
             var success = await generator.GenerateManifest(translationPath, manifestPath);
 
             if (!success)
@@ -537,11 +548,25 @@ class Program
                 logger.LogError("Failed to generate manifest");
                 Environment.Exit(1);
             }
-            
+
             logger.LogInformation("Manifest generated successfully at {manifestPath}", manifestPath);
         }, translationPathOption, manifestPathOption);
-        
+
         return command;
+    }
+
+    private static string ResolveProjectDirectory()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "BTCPayTranslator.csproj")))
+                return directory.FullName;
+            directory = directory.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate the Translator project directory (BTCPayTranslator.csproj) " +
+            "anywhere above AppContext.BaseDirectory.");
     }
 
 }

--- a/Translator/Program.cs
+++ b/Translator/Program.cs
@@ -500,20 +500,13 @@ class Program
     
     private static Command CreateGenerateManifestCommand(ServiceProvider serviceProvider)
     {
-        // Anchor default paths to the Translator project directory rather than to
-        // the caller's cwd. The generator should produce the same manifest whether
-        // a contributor runs `dotnet run --project Translator` from the repo root,
-        // from inside Translator/, or via the `manifest.yml` workflow with its
-        // explicit `working-directory: Translator`. Walk up from
-        // AppContext.BaseDirectory looking for BTCPayTranslator.csproj; the
-        // containing directory is the project root.
         var projectDirectory = ResolveProjectDirectory();
         var defaultTranslationPath = Path.Combine(projectDirectory, "translations");
         var defaultManifestPath = Path.Combine(projectDirectory, "..", "manifest.json");
 
         var translationPathOption = new Option<string>(
             "--translation-path",
-            "Path to the translations folder. Defaults to <project-dir>/translations.")
+            "Path to the translations folder. Defaults to <repo-root>/Translator/translations.")
         {
             IsRequired = false
         };

--- a/Translator/Services/ManifestGenerator.cs
+++ b/Translator/Services/ManifestGenerator.cs
@@ -72,7 +72,7 @@ public class ManifestGenerator
         }
     }
 
-    private async Task<ManifestEntry> BuildEntry(string filePath)
+    private async Task<ManifestEntry> BuildEntry(string filePath,ManifestEntry? existingEntry)
     {
         try
         {
@@ -94,8 +94,8 @@ public class ManifestGenerator
             }
 
             var maintainer = GetMaintainer(filePath);
-
-            var updatedAt = GetUpdatedAt();
+            
+            var updatedAt = existingEntry?.Sha == hashedFile ? existingEntry!.Updated : GetUpdatedAt();
 
             var entry = new ManifestEntry(
                 Code: code,
@@ -121,6 +121,14 @@ public class ManifestGenerator
         try
         {
             _logger.LogInformation("Starting manifest generation");
+            
+            Manifest? existingManifest = null;
+            if (File.Exists(manifestOutputPath))
+            {
+                var existingJson = await File.ReadAllTextAsync(manifestOutputPath);
+                existingManifest = JsonSerializer.Deserialize<Manifest>(existingJson);
+            }
+            
             var files = GetTranslationFiles(translationDirectoryPath)?.ToArray();
             if (files == null || files.Length == 0)
             {
@@ -131,7 +139,10 @@ public class ManifestGenerator
             var entries = new List<ManifestEntry>();
             foreach (var file in files)
             {
-                var entry = await BuildEntry(file);
+                var existingEntry = existingManifest?.Languages
+                    .FirstOrDefault(e => e.File == "translations/" + Path.GetFileName(file));
+    
+                var entry = await BuildEntry(file, existingEntry);
                 entries.Add(entry);
             }
 

--- a/Translator/Services/ManifestGenerator.cs
+++ b/Translator/Services/ManifestGenerator.cs
@@ -10,31 +10,25 @@ using Microsoft.Extensions.Logging;
 
 namespace BTCPayTranslator.Services;
 
-// TODO : expose this with a CLI command
-
 public class ManifestGenerator
 {
-    private readonly string _translationPath;
-    private readonly string _manifestOutputPath;
-    private static DateTime GetUpdatedAt() => DateTime.UtcNow;
+    private static string GetUpdatedAt() => DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
     private readonly ILogger<ManifestGenerator> _logger;
     
-    public ManifestGenerator(ILogger<ManifestGenerator> logger, string translationPath, string manifestOutputPath)
+    public ManifestGenerator(ILogger<ManifestGenerator> logger)
     {
         _logger = logger;
-        _translationPath =  translationPath;
-        _manifestOutputPath = manifestOutputPath; 
     }
 
-    private IEnumerable<string>? GetTranslationFiles()
+    private IEnumerable<string>? GetTranslationFiles(string translationDirectoryPath)
     {
         try
         {
-            return Directory.GetFiles(_translationPath, "*.json");
+            return Directory.GetFiles(translationDirectoryPath, "*.json");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Couldn't find translation files in {Directory}", _translationPath);
+            _logger.LogError(ex, "Couldn't find translation files in {Directory}", translationDirectoryPath);
             throw new Exception("Couldn't find translation files", ex);
         }
         
@@ -122,12 +116,12 @@ public class ManifestGenerator
         }
     }
 
-    public async Task<bool> GenerateManifest()
+    public async Task<bool> GenerateManifest(string translationDirectoryPath, string manifestOutputPath)
     {
         try
         {
             _logger.LogInformation("Starting manifest generation");
-            var files = GetTranslationFiles()?.ToArray();
+            var files = GetTranslationFiles(translationDirectoryPath)?.ToArray();
             if (files == null || files.Length == 0)
             {
                 _logger.LogError("No translation files found to generate manifest");
@@ -145,15 +139,16 @@ public class ManifestGenerator
 
             var manifestJson = JsonSerializer.Serialize(manifest, new JsonSerializerOptions
             {
-                WriteIndented = true
+                WriteIndented = true,
+                Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             });
  
             await File.WriteAllTextAsync(
-                _manifestOutputPath, 
+                manifestOutputPath, 
                 manifestJson
             );
 
-            _logger.LogInformation("Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}", entries.Count, files.Length, _manifestOutputPath);
+            _logger.LogInformation("Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}", entries.Count, files.Length, manifestOutputPath);
             return true;
         }
         catch (Exception ex)

--- a/Translator/Services/ManifestGenerator.cs
+++ b/Translator/Services/ManifestGenerator.cs
@@ -79,7 +79,7 @@ public class ManifestGenerator
         {
             var fileName = Path.GetFileNameWithoutExtension(filePath);
 
-            var result = SupportedLanguages.GetLanguageInfoByFileName(fileName);
+            var result = SupportedLanguages.GetLanguageInfoByName(fileName);
             if (!result.HasValue)
             {
                 _logger.LogError("No language info mapping found for translation file {FileName}", fileName);
@@ -95,11 +95,7 @@ public class ManifestGenerator
             }
 
             var maintainer = await GetMaintainer(filePath);
-
-            // SHA-stable Updated: preserve the previous timestamp when the file hasn't
-            // changed since the last manifest. Otherwise stamp with the run's single
-            // UTC timestamp (captured once in GenerateManifest, not per file - so
-            // multiple changed files in one run share one timestamp).
+            
             var updatedAt = existingEntry?.Sha == hashedFile ? existingEntry!.Updated : runUpdatedAt;
 
             var entry = new ManifestEntry(
@@ -127,8 +123,6 @@ public class ManifestGenerator
         {
             _logger.LogInformation("Starting manifest generation");
 
-            // Capture the run's UTC stamp once so all changed files in this run share
-            // one Updated value rather than drifting per file.
             var runUpdatedAt = FormatUtcTimestamp(DateTime.UtcNow);
 
             Manifest? existingManifest = null;
@@ -138,7 +132,7 @@ public class ManifestGenerator
                 existingManifest = JsonSerializer.Deserialize<Manifest>(existingJson);
             }
 
-            var files = GetTranslationFiles(translationDirectoryPath)?.ToArray();
+            var files = GetTranslationFiles(translationDirectoryPath)?.OrderBy(f=> f).ToArray();
             if (files == null || files.Length == 0)
             {
                 _logger.LogError("No translation files found to generate manifest");
@@ -151,11 +145,6 @@ public class ManifestGenerator
                 var existingEntry = existingManifest?.Languages
                     .FirstOrDefault(e => e.File == "translations/" + Path.GetFileName(file));
 
-                // Fail-fast posture: a per-file failure (missing language mapping,
-                // invalid JSON, unreadable hash) aborts the whole run rather than
-                // emitting a partial manifest. Recovery path is the manifest.yml
-                // workflow_dispatch trigger - fix the offending file and re-run
-                // manually rather than letting a broken language silently linger.
                 var entry = await BuildEntry(file, existingEntry, runUpdatedAt);
                 entries.Add(entry);
             }
@@ -170,9 +159,7 @@ public class ManifestGenerator
 
             await File.WriteAllTextAsync(manifestOutputPath, manifestJson);
 
-            _logger.LogInformation(
-                "Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}",
-                entries.Count, files.Length, manifestOutputPath);
+            _logger.LogInformation("Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}", entries.Count, files.Length, manifestOutputPath);
             return true;
         }
         catch (Exception ex)

--- a/Translator/Services/ManifestGenerator.cs
+++ b/Translator/Services/ManifestGenerator.cs
@@ -12,9 +12,11 @@ namespace BTCPayTranslator.Services;
 
 public class ManifestGenerator
 {
-    private static string GetUpdatedAt() => DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+    private static string FormatUtcTimestamp(DateTime utc) =>
+        utc.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
     private readonly ILogger<ManifestGenerator> _logger;
-    
+
     public ManifestGenerator(ILogger<ManifestGenerator> logger)
     {
         _logger = logger;
@@ -31,16 +33,15 @@ public class ManifestGenerator
             _logger.LogError(ex, "Couldn't find translation files in {Directory}", translationDirectoryPath);
             throw new Exception("Couldn't find translation files", ex);
         }
-        
     }
-    
+
     private async Task<string?> HashFiles(string filePath)
     {
         using var sha256 = SHA256.Create();
         try
         {
             await using var stream = File.OpenRead(filePath);
-            var hashBytes = await  sha256.ComputeHashAsync(stream);
+            var hashBytes = await sha256.ComputeHashAsync(stream);
             return Convert.ToHexString(hashBytes).ToLower();
         }
         catch (Exception ex)
@@ -50,11 +51,11 @@ public class ManifestGenerator
         }
     }
 
-    private string? GetMaintainer(string filePath)
+    private async Task<string?> GetMaintainer(string filePath)
     {
         try
         {
-            var json = File.ReadAllText(filePath);
+            var json = await File.ReadAllTextAsync(filePath);
             using var document = JsonDocument.Parse(json);
             var root = document.RootElement;
             if (root.TryGetProperty("_maintainer", out var maintainer))
@@ -72,13 +73,13 @@ public class ManifestGenerator
         }
     }
 
-    private async Task<ManifestEntry> BuildEntry(string filePath,ManifestEntry? existingEntry)
+    private async Task<ManifestEntry> BuildEntry(string filePath, ManifestEntry? existingEntry, string runUpdatedAt)
     {
         try
         {
             var fileName = Path.GetFileNameWithoutExtension(filePath);
 
-            var result = SupportedLanguages.GetLanguageInfoByName(fileName);
+            var result = SupportedLanguages.GetLanguageInfoByFileName(fileName);
             if (!result.HasValue)
             {
                 _logger.LogError("No language info mapping found for translation file {FileName}", fileName);
@@ -93,9 +94,13 @@ public class ManifestGenerator
                 throw new Exception($"Hash generation failed for {filePath}");
             }
 
-            var maintainer = GetMaintainer(filePath);
-            
-            var updatedAt = existingEntry?.Sha == hashedFile ? existingEntry!.Updated : GetUpdatedAt();
+            var maintainer = await GetMaintainer(filePath);
+
+            // SHA-stable Updated: preserve the previous timestamp when the file hasn't
+            // changed since the last manifest. Otherwise stamp with the run's single
+            // UTC timestamp (captured once in GenerateManifest, not per file - so
+            // multiple changed files in one run share one timestamp).
+            var updatedAt = existingEntry?.Sha == hashedFile ? existingEntry!.Updated : runUpdatedAt;
 
             var entry = new ManifestEntry(
                 Code: code,
@@ -106,7 +111,7 @@ public class ManifestGenerator
                 Sha: hashedFile,
                 Maintainer: maintainer,
                 Updated: updatedAt);
-            
+
             return entry;
         }
         catch (Exception ex)
@@ -121,14 +126,18 @@ public class ManifestGenerator
         try
         {
             _logger.LogInformation("Starting manifest generation");
-            
+
+            // Capture the run's UTC stamp once so all changed files in this run share
+            // one Updated value rather than drifting per file.
+            var runUpdatedAt = FormatUtcTimestamp(DateTime.UtcNow);
+
             Manifest? existingManifest = null;
             if (File.Exists(manifestOutputPath))
             {
                 var existingJson = await File.ReadAllTextAsync(manifestOutputPath);
                 existingManifest = JsonSerializer.Deserialize<Manifest>(existingJson);
             }
-            
+
             var files = GetTranslationFiles(translationDirectoryPath)?.ToArray();
             if (files == null || files.Length == 0)
             {
@@ -141,8 +150,13 @@ public class ManifestGenerator
             {
                 var existingEntry = existingManifest?.Languages
                     .FirstOrDefault(e => e.File == "translations/" + Path.GetFileName(file));
-    
-                var entry = await BuildEntry(file, existingEntry);
+
+                // Fail-fast posture: a per-file failure (missing language mapping,
+                // invalid JSON, unreadable hash) aborts the whole run rather than
+                // emitting a partial manifest. Recovery path is the manifest.yml
+                // workflow_dispatch trigger - fix the offending file and re-run
+                // manually rather than letting a broken language silently linger.
+                var entry = await BuildEntry(file, existingEntry, runUpdatedAt);
                 entries.Add(entry);
             }
 
@@ -153,13 +167,12 @@ public class ManifestGenerator
                 WriteIndented = true,
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
             });
- 
-            await File.WriteAllTextAsync(
-                manifestOutputPath, 
-                manifestJson
-            );
 
-            _logger.LogInformation("Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}", entries.Count, files.Length, manifestOutputPath);
+            await File.WriteAllTextAsync(manifestOutputPath, manifestJson);
+
+            _logger.LogInformation(
+                "Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}",
+                entries.Count, files.Length, manifestOutputPath);
             return true;
         }
         catch (Exception ex)

--- a/Translator/Services/ManifestGenerator.cs
+++ b/Translator/Services/ManifestGenerator.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using BTCPayTranslator.Models;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayTranslator.Services;
+
+// TODO : expose this with a CLI command
+
+public class ManifestGenerator
+{
+    private readonly string _translationPath;
+    private readonly string _manifestOutputPath;
+    private static DateTime GetUpdatedAt() => DateTime.UtcNow;
+    private readonly ILogger<ManifestGenerator> _logger;
+    
+    public ManifestGenerator(ILogger<ManifestGenerator> logger, string translationPath, string manifestOutputPath)
+    {
+        _logger = logger;
+        _translationPath =  translationPath;
+        _manifestOutputPath = manifestOutputPath; 
+    }
+
+    private IEnumerable<string>? GetTranslationFiles()
+    {
+        try
+        {
+            return Directory.GetFiles(_translationPath, "*.json");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Couldn't find translation files in {Directory}", _translationPath);
+            throw new Exception("Couldn't find translation files", ex);
+        }
+        
+    }
+    
+    private async Task<string?> HashFiles(string filePath)
+    {
+        using var sha256 = SHA256.Create();
+        try
+        {
+            await using var stream = File.OpenRead(filePath);
+            var hashBytes = await  sha256.ComputeHashAsync(stream);
+            return Convert.ToHexString(hashBytes).ToLower();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to hash file {FilePath}", filePath);
+            throw new Exception("Couldn't hash translation file", ex);
+        }
+    }
+
+    private string? GetMaintainer(string filePath)
+    {
+        try
+        {
+            var json = File.ReadAllText(filePath);
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
+            if (root.TryGetProperty("_maintainer", out var maintainer))
+            {
+                return maintainer.GetString();
+            }
+
+            _logger.LogWarning("Missing _maintainer field in {FilePath}", filePath);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read maintainer from {FilePath}", filePath);
+            throw new Exception("Couldn't read maintainer from translation file", ex);
+        }
+    }
+
+    private async Task<ManifestEntry> BuildEntry(string filePath)
+    {
+        try
+        {
+            var fileName = Path.GetFileNameWithoutExtension(filePath);
+
+            var result = SupportedLanguages.GetLanguageInfoByName(fileName);
+            if (!result.HasValue)
+            {
+                _logger.LogError("No language info mapping found for translation file {FileName}", fileName);
+                throw new Exception($"No language info found for {fileName}");
+            }
+            var (code, langInfo) = result.Value;
+
+            var hashedFile = await HashFiles(filePath);
+            if (hashedFile == null)
+            {
+                _logger.LogError("Skipping {FilePath} because hash generation failed", filePath);
+                throw new Exception($"Hash generation failed for {filePath}");
+            }
+
+            var maintainer = GetMaintainer(filePath);
+
+            var updatedAt = GetUpdatedAt();
+
+            var entry = new ManifestEntry(
+                Code: code,
+                Bcp47: langInfo.Code,
+                Name: langInfo.Name,
+                Native: langInfo.NativeName,
+                File: "translations/" + fileName + ".json",
+                Sha: hashedFile,
+                Maintainer: maintainer,
+                Updated: updatedAt);
+            
+            return entry;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to build manifest entry for {FilePath}", filePath);
+            throw new Exception("Couldn't build manifest entry", ex);
+        }
+    }
+
+    public async Task<bool> GenerateManifest()
+    {
+        try
+        {
+            _logger.LogInformation("Starting manifest generation");
+            var files = GetTranslationFiles()?.ToArray();
+            if (files == null || files.Length == 0)
+            {
+                _logger.LogError("No translation files found to generate manifest");
+                return false;
+            }
+
+            var entries = new List<ManifestEntry>();
+            foreach (var file in files)
+            {
+                var entry = await BuildEntry(file);
+                entries.Add(entry);
+            }
+
+            var manifest = new Manifest(entries, Redirect: null);
+
+            var manifestJson = JsonSerializer.Serialize(manifest, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+ 
+            await File.WriteAllTextAsync(
+                _manifestOutputPath, 
+                manifestJson
+            );
+
+            _logger.LogInformation("Manifest generated with {EntryCount}/{FileCount} entries at {ManifestPath}", entries.Count, files.Length, _manifestOutputPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Manifest generation failed");
+            return false;
+        }
+    }
+}

--- a/Translator/translations/french.json
+++ b/Translator/translations/french.json
@@ -2269,7 +2269,7 @@
   "Your email server has not been configured.": "Votre serveur de messagerie n'a pas été configuré.",
   "Your existing recovery codes will no longer be valid!": "Vos codes de récupération existants ne seront plus valides !",
   "Your instance administrator has disabled the use of the Internal node for non-admin users.": "Votre administrateur de l'instance a désactivé l'utilisation du nœud interne pour les utilisateurs non-administrateurs.",
-  "Your node address: {0}": "Votre adresse de nœud : {0}",
+  "Your node address: {0}": "L'adresse de votre noeud : {0}",
   "Your password has been changed.": "Votre mot de passe a été modifié.",
   "Your password has been set by the user who invited you.": "Votre mot de passe a été défini par l'utilisateur qui vous a invité.",
   "Your password has been set.": "Votre mot de passe a été défini.",


### PR DESCRIPTION
This PR tracks Phase 1 of the [BTCPay Server translations revamp roadmap](https://docs.google.com/document/d/1mO0MuWrZ-vwSpN1qkXj2aREj62vG2DEam4yYDN10gu4/edit).

## Changes

- `ManifestGenerator` service : build and write the manifest file
- CLI Command `generate-manifest` : (`dotnet run -- generate-manifest`)
- CI workflow : triggers on push to `main` when a translation file changes + runs `generate-manifest` command, commits and pushes `manifest.json`
- Test suite : covers `ManifestGenerator` service