### PR TITLE
fix(serbian): drop invented {…} placeholder from 'Invalid email address or placeholder detected'

### DIFF
--- a/translations/serbian.json
+++ b/translations/serbian.json
@@ -888,7 +888,7 @@
   "Invalid currency pairs (should be for example: {0})": "Neispravni parovi valuta (trebalo bi da bude na primer: {0})",
   "Invalid destination or payment method": "Neispravna destinacija ili metod plaćanja",
   "Invalid email": "Neispravna email adresa",
-  "Invalid email address or placeholder detected": "Jedna od email adresa ili vrednosti u formatu {…} za primaoca nije ispravna.",
+  "Invalid email address or placeholder detected": "Neispravna email adresa ili čuvar mesta.",
   "Invalid file name": "Nevažeće ime fajla",
   "Invalid login attempt.": "Prijava nije uspela.",
   "Invalid network": "Neispravna mreža",


### PR DESCRIPTION
Per @Sanja22B's request in `-5292199939` 2026-05-26 13:34 UTC, opening this PR from the anti-slop pass on serbian.json.

## What

One entry in `translations/serbian.json` introduced a `{…}` format-token in the Serbian translation that doesn't exist in the English source:

- English: `Invalid email address or placeholder detected`
- Serbian (before): `Jedna od email adresa ili vrednosti u formatu {…} za primaoca nije ispravna.`
- Serbian (after): `Neispravna email adresa ili čuvar mesta.`

The `{…}` ellipsis-in-braces was the translator's attempt to render "placeholder" concretely by showing what one looks like. It works, but it doesn't match the source structure and other localizations don't use this device.

Rewriting as a more literal mapping aligns with the source.

## Caveats

I'm not a native Serbian speaker. `čuvar mesta` is a literal best-attempt translation of "placeholder" ("place-keeper"). If a different word or phrasing fits Serbian software-localization conventions better, please push a maintainer-edit on this branch or comment with the preferred wording and I'll update.

## Out of scope

The anti-slop pass also flagged 38 other entries in serbian.json as identical-to-English (Server, Token, Limit, Port, Checkout, Crowdfund, Placeholders, Plugin server, Value Mapper, etc.). These are judgment calls on which tech anglicisms to keep vs translate, deliberately left for the maintainer to decide rather than batched into this fix. Full report markdown available on request.

## Context

Anti-slop pass triggered by @teamssUTXO msg 472 / 476 / 478 in the BTCPay Translations Telegram group 2026-05-26. Pass scope: `_maintainer`-tagged languages except French + Spanish (Portuguese-BR, Serbian, Hindi). Sanya is the serbian.json maintainer per `_maintainer: sanya|https://github.com/Sanja22B`.