### PR TITLE
feat(validator): HTML-tag-mismatch + _maintainer shape + wire validate-packs into CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,6 @@ jobs:
         run: dotnet test --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
       - name: Validate translation packs
-        # Runs validate-packs CLI against the in-repo translations/ folder.
-        # continue-on-error keeps the step report-only initially - the new
-        # HTML-tag-mismatch + _maintainer rules surface known pre-existing
-        # issues in hindi/indonesian/thai/romanian language packs that need
-        # maintainer follow-up. Once those are fixed, drop continue-on-error
-        # so CI gates new slop entries from landing.
         continue-on-error: true
         env:
           Translation__OutputDirectory: ${{ github.workspace }}/translations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Unit Tests
         run: dotnet test --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
 
+      - name: Validate translation packs
+        # Runs validate-packs CLI against the in-repo translations/ folder.
+        # continue-on-error keeps the step report-only initially - the new
+        # HTML-tag-mismatch + _maintainer rules surface known pre-existing
+        # issues in hindi/indonesian/thai/romanian language packs that need
+        # maintainer follow-up. Once those are fixed, drop continue-on-error
+        # so CI gates new slop entries from landing.
+        continue-on-error: true
+        env:
+          Translation__OutputDirectory: ${{ github.workspace }}/translations
+        run: dotnet run --project Translator/BTCPayTranslator.csproj --configuration Release --no-build -- validate-packs
+
       - name: Upload test logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/Translator.Tests/Services/LanguagePackValidatorTests.cs
+++ b/Translator.Tests/Services/LanguagePackValidatorTests.cs
@@ -128,6 +128,173 @@ public class LanguagePackValidatorTests
         }
     }
 
+    [Fact]
+    public async Task ValidateAsync_FlagsHtmlTagMismatch()
+    {
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "hindi.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "<strong>Never</strong> trust anything but <code>id</code>": "केवल <code>id</code> पर भरोसा करें",
+                  "kept-intact": "<code>foo</code> bar <code>baz</code>"
+                }
+                """.Replace("<code>foo</code> bar <code>baz</code>",
+                            "<code>foo</code> bar <code>baz</code>"));
+
+            // Re-write with a balanced kept-intact entry so only the first entry fails the rule
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "<strong>Never</strong> trust anything but <code>id</code>": "केवल <code>id</code> पर भरोसा करें",
+                  "<code>foo</code>": "<code>foo</code>"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            Assert.Equal(2, result.EntriesScanned);
+            var issue = Assert.Single(result.Issues);
+            Assert.StartsWith("<strong>Never", issue.Key);
+            Assert.Contains("Structural HTML tag mismatch", issue.Reason);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_IgnoresExampleEmailAngleBrackets()
+    {
+        // The HTML-tag check uses a curated allowlist of structural elements
+        // (strong/em/code/br/p/a/etc.) so localized example data like
+        // "<email@primer.com>" doesn't trip the rule even though the bare
+        // HtmlTagRegex would match it.
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "serbian.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "Firstname Lastname <email@example.com>": "Ime Prezime <email@primer.com>"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            Assert.Equal(1, result.EntriesScanned);
+            Assert.Empty(result.Issues);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_FlagsInvalidMaintainerField()
+    {
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "bad-maintainer.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "_maintainer": "someone with no pipe or URL",
+                  "hello": "bonjour"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            // _maintainer is not counted as a translation entry
+            Assert.Equal(1, result.EntriesScanned);
+            var issue = Assert.Single(result.Issues);
+            Assert.Equal("_maintainer", issue.Key);
+            Assert.Contains("Invalid _maintainer value", issue.Reason);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_AcceptsWellFormedMaintainerField()
+    {
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "ok-maintainer.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "_maintainer": "thgO-O|https://github.com/thgO-O",
+                  "hello": "olá"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            Assert.Equal(1, result.EntriesScanned);
+            Assert.Empty(result.Issues);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_RejectsMaintainerWithHttpScheme()
+    {
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "http-maintainer.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "_maintainer": "thgO-O|http://github.com/thgO-O"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            var issue = Assert.Single(result.Issues);
+            Assert.Equal("_maintainer", issue.Key);
+            Assert.Contains("Invalid _maintainer", issue.Reason);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
     private static LanguagePackValidator CreateSut(string outputDirectory)
     {
         var configuration = new ConfigurationBuilder()

--- a/Translator.Tests/Services/LanguagePackValidatorTests.cs
+++ b/Translator.Tests/Services/LanguagePackValidatorTests.cs
@@ -295,6 +295,68 @@ public class LanguagePackValidatorTests
         }
     }
 
+    [Fact]
+    public async Task ValidateAsync_AcceptsNullMaintainerField()
+    {
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "null-maintainer.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "_maintainer": null,
+                  "hello": "hei"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            Assert.Equal(1, result.EntriesScanned);
+            Assert.Empty(result.Issues);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ValidateAsync_RejectsBlankMaintainerField_WhenPresent()
+    {
+        var tempDir = CreateTempDirectory();
+
+        try
+        {
+            var filePath = Path.Combine(tempDir, "blank-maintainer.json");
+            await File.WriteAllTextAsync(filePath, """
+                {
+                  "_maintainer": "   ",
+                  "hello": "hei"
+                }
+                """);
+
+            var sut = CreateSut(tempDir);
+            var result = await sut.ValidateAsync(fix: false);
+
+            Assert.Equal(1, result.EntriesScanned);
+            var issue = Assert.Single(result.Issues);
+            Assert.Equal("_maintainer", issue.Key);
+            Assert.Contains("Invalid _maintainer", issue.Reason);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
     private static LanguagePackValidator CreateSut(string outputDirectory)
     {
         var configuration = new ConfigurationBuilder()

--- a/Translator/Services/LanguagePackValidator.cs
+++ b/Translator/Services/LanguagePackValidator.cs
@@ -73,6 +73,21 @@ public class LanguagePackValidator
             {
                 var key = property.Name;
                 var value = property.Value?.ToString() ?? string.Empty;
+
+                // The _maintainer field is metadata, not a translation entry.
+                // Validate its shape independently and skip the per-entry rules.
+                if (key.Equals("_maintainer", StringComparison.Ordinal))
+                {
+                    if (!TranslationValidationRules.IsValidMaintainerValue(value))
+                    {
+                        issues.Add(new ValidationIssue(
+                            Path.GetFileName(filePath),
+                            key,
+                            "Invalid _maintainer value (expected '<display name or handle>|<https URL>')"));
+                    }
+                    continue;
+                }
+
                 totalEntries++;
 
                 if (TranslationValidationRules.IsSuspiciousMetaResponse(value))
@@ -112,6 +127,19 @@ public class LanguagePackValidator
                     {
                         fileChanged |= ApplyFix(property, key, value);
                     }
+                    continue;
+                }
+
+                if (!TranslationValidationRules.HasMatchingHtmlTags(key, value))
+                {
+                    issues.Add(new ValidationIssue(
+                        Path.GetFileName(filePath),
+                        key,
+                        "Structural HTML tag mismatch between source key and translation"));
+                    // Auto-fix is intentionally skipped here: restoring the
+                    // English source would lose the translated prose around
+                    // the tags. Maintainer needs to re-anchor the markup by
+                    // hand.
                 }
             }
 

--- a/Translator/Services/LanguagePackValidator.cs
+++ b/Translator/Services/LanguagePackValidator.cs
@@ -76,7 +76,9 @@ public class LanguagePackValidator
                 
                 if (key.Equals("_maintainer", StringComparison.Ordinal))
                 {
-                    if (!TranslationValidationRules.IsValidMaintainerValue(value))
+                    var maintainerValue = property.Value?.Type == JTokenType.Null ? null : value;
+
+                    if (!TranslationValidationRules.IsValidMaintainerValue(maintainerValue))
                     {
                         issues.Add(new ValidationIssue(Path.GetFileName(filePath), key,
                             "Invalid _maintainer value (expected '<display name or handle>|<https URL>')"));

--- a/Translator/Services/LanguagePackValidator.cs
+++ b/Translator/Services/LanguagePackValidator.cs
@@ -73,16 +73,12 @@ public class LanguagePackValidator
             {
                 var key = property.Name;
                 var value = property.Value?.ToString() ?? string.Empty;
-
-                // The _maintainer field is metadata, not a translation entry.
-                // Validate its shape independently and skip the per-entry rules.
+                
                 if (key.Equals("_maintainer", StringComparison.Ordinal))
                 {
                     if (!TranslationValidationRules.IsValidMaintainerValue(value))
                     {
-                        issues.Add(new ValidationIssue(
-                            Path.GetFileName(filePath),
-                            key,
+                        issues.Add(new ValidationIssue(Path.GetFileName(filePath), key,
                             "Invalid _maintainer value (expected '<display name or handle>|<https URL>')"));
                     }
                     continue;
@@ -132,14 +128,9 @@ public class LanguagePackValidator
 
                 if (!TranslationValidationRules.HasMatchingHtmlTags(key, value))
                 {
-                    issues.Add(new ValidationIssue(
-                        Path.GetFileName(filePath),
-                        key,
+                    issues.Add(new ValidationIssue(Path.GetFileName(filePath), key,
                         "Structural HTML tag mismatch between source key and translation"));
-                    // Auto-fix is intentionally skipped here: restoring the
-                    // English source would lose the translated prose around
-                    // the tags. Maintainer needs to re-anchor the markup by
-                    // hand.
+                    // Auto-fix is intentionally skipped here. Maintainer needs to re-anchor the markup by hand.
                 }
             }
 

--- a/Translator/Services/TranslationValidationRules.cs
+++ b/Translator/Services/TranslationValidationRules.cs
@@ -13,6 +13,21 @@ internal static class TranslationValidationRules
     private static readonly Regex HtmlTagRegex =
         new(@"<[^>]+>", RegexOptions.Compiled);
 
+    // Recognised HTML/markup tags whose presence/absence in translations is
+    // load-bearing for the UI. Restricting the multiset comparison to this
+    // allowlist keeps the rule from false-flagging localized example data
+    // like "<email@primer.com>" or "<John Doe>" which the bare HtmlTagRegex
+    // also matches.
+    private static readonly Regex StructuralHtmlTagRegex =
+        new(@"<\s*/?\s*(strong|em|b|i|u|code|pre|kbd|small|sub|sup|mark|br|p|div|span|a|ul|ol|li|h[1-6]|table|thead|tbody|tr|td|th|abbr|del|ins|q|cite|var|samp)\b[^>]*>",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // Maintainer field shape: "<display name or handle>|<https URL>". The
+    // pipe + URL gives us a stable parse for the manifest generator + lets
+    // us catch malformed entries (missing pipe, non-https URL, empty parts).
+    private static readonly Regex MaintainerFieldRegex =
+        new(@"^[^|]+\|https://\S+$", RegexOptions.Compiled);
+
     private static readonly Regex WhitespaceRegex =
         new(@"\s+", RegexOptions.Compiled);
 
@@ -246,6 +261,46 @@ internal static class TranslationValidationRules
         return true;
     }
 
+    /// <summary>
+    /// Checks that the source and translation use the same multiset of structural
+    /// HTML tags (case-insensitive). Catches accidental drops or extras like a
+    /// missing closing &lt;/strong&gt; or a lost &lt;code&gt; pair in a translated
+    /// block - both of which silently break rendering. Only counts tags from a
+    /// curated allowlist of real markup elements so localized example data
+    /// (&lt;email@primer.com&gt;, &lt;John Doe&gt;) doesn't trip the rule.
+    /// </summary>
+    public static bool HasMatchingHtmlTags(string source, string translation)
+    {
+        var sourceTags = ExtractStructuralTagCounts(source);
+        var translationTags = ExtractStructuralTagCounts(translation);
+
+        if (sourceTags.Count != translationTags.Count)
+            return false;
+
+        foreach (var entry in sourceTags)
+        {
+            if (!translationTags.TryGetValue(entry.Key, out var count) || count != entry.Value)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validates the shape of the _maintainer field that ManifestGenerator expects:
+    /// "&lt;display name or handle&gt;|&lt;https URL&gt;". Missing pipe, missing URL,
+    /// or non-https URL all fail. Empty / whitespace value is treated as
+    /// "field present but unset" - the file-level scanner flags that separately
+    /// if it cares about presence.
+    /// </summary>
+    public static bool IsValidMaintainerValue(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        return MaintainerFieldRegex.IsMatch(value.Trim());
+    }
+
     public static bool IsLikelySentenceFallback(string source, string translation)
     {
         if (!string.Equals(source, translation, StringComparison.Ordinal))
@@ -296,6 +351,30 @@ internal static class TranslationValidationRules
             {
                 counts[match.Value]++;
             }
+        }
+
+        return counts;
+    }
+
+    private static readonly Regex TagNameRegex =
+        new(@"<\s*/?\s*([A-Za-z][A-Za-z0-9]*)", RegexOptions.Compiled);
+
+    private static Dictionary<string, int> ExtractStructuralTagCounts(string text)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (Match match in StructuralHtmlTagRegex.Matches(text))
+        {
+            // Key on tag name + open-vs-close so <code> and </code> are tracked
+            // separately (dropped closing tags are the common bug). <CODE> and
+            // <code> are folded since HTML tag names are case-insensitive.
+            var raw = match.Value;
+            var nameMatch = TagNameRegex.Match(raw);
+            if (!nameMatch.Success) continue;
+            var isClose = raw.TrimStart('<').TrimStart().StartsWith('/');
+            var key = (isClose ? "/" : string.Empty) + nameMatch.Groups[1].Value.ToLowerInvariant();
+            if (!counts.TryAdd(key, 1))
+                counts[key]++;
         }
 
         return counts;

--- a/Translator/Services/TranslationValidationRules.cs
+++ b/Translator/Services/TranslationValidationRules.cs
@@ -276,11 +276,14 @@ internal static class TranslationValidationRules
     /// <summary>
     /// Validates the shape of the _maintainer field that ManifestGenerator expects
     /// </summary>
-    public static bool IsValidMaintainerValue(string value)
+    public static bool IsValidMaintainerValue(string? value)
     {
         // if language don't have maintainer
-        if (string.IsNullOrWhiteSpace(value))
+        if (value is null)
             return true;
+        
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
 
         return MaintainerFieldRegex.IsMatch(value.Trim());
     }

--- a/Translator/Services/TranslationValidationRules.cs
+++ b/Translator/Services/TranslationValidationRules.cs
@@ -13,18 +13,10 @@ internal static class TranslationValidationRules
     private static readonly Regex HtmlTagRegex =
         new(@"<[^>]+>", RegexOptions.Compiled);
 
-    // Recognised HTML/markup tags whose presence/absence in translations is
-    // load-bearing for the UI. Restricting the multiset comparison to this
-    // allowlist keeps the rule from false-flagging localized example data
-    // like "<email@primer.com>" or "<John Doe>" which the bare HtmlTagRegex
-    // also matches.
     private static readonly Regex StructuralHtmlTagRegex =
         new(@"<\s*/?\s*(strong|em|b|i|u|code|pre|kbd|small|sub|sup|mark|br|p|div|span|a|ul|ol|li|h[1-6]|table|thead|tbody|tr|td|th|abbr|del|ins|q|cite|var|samp)\b[^>]*>",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    // Maintainer field shape: "<display name or handle>|<https URL>". The
-    // pipe + URL gives us a stable parse for the manifest generator + lets
-    // us catch malformed entries (missing pipe, non-https URL, empty parts).
+    
     private static readonly Regex MaintainerFieldRegex =
         new(@"^[^|]+\|https://\S+$", RegexOptions.Compiled);
 
@@ -262,12 +254,7 @@ internal static class TranslationValidationRules
     }
 
     /// <summary>
-    /// Checks that the source and translation use the same multiset of structural
-    /// HTML tags (case-insensitive). Catches accidental drops or extras like a
-    /// missing closing &lt;/strong&gt; or a lost &lt;code&gt; pair in a translated
-    /// block - both of which silently break rendering. Only counts tags from a
-    /// curated allowlist of real markup elements so localized example data
-    /// (&lt;email@primer.com&gt;, &lt;John Doe&gt;) doesn't trip the rule.
+    /// Checks that the source and translation use the same multiset of structural HTML tags (case-insensitive).
     /// </summary>
     public static bool HasMatchingHtmlTags(string source, string translation)
     {
@@ -287,16 +274,13 @@ internal static class TranslationValidationRules
     }
 
     /// <summary>
-    /// Validates the shape of the _maintainer field that ManifestGenerator expects:
-    /// "&lt;display name or handle&gt;|&lt;https URL&gt;". Missing pipe, missing URL,
-    /// or non-https URL all fail. Empty / whitespace value is treated as
-    /// "field present but unset" - the file-level scanner flags that separately
-    /// if it cares about presence.
+    /// Validates the shape of the _maintainer field that ManifestGenerator expects
     /// </summary>
     public static bool IsValidMaintainerValue(string value)
     {
+        // if language don't have maintainer
         if (string.IsNullOrWhiteSpace(value))
-            return false;
+            return true;
 
         return MaintainerFieldRegex.IsMatch(value.Trim());
     }
@@ -356,8 +340,7 @@ internal static class TranslationValidationRules
         return counts;
     }
 
-    private static readonly Regex TagNameRegex =
-        new(@"<\s*/?\s*([A-Za-z][A-Za-z0-9]*)", RegexOptions.Compiled);
+    private static readonly Regex TagNameRegex = new(@"<\s*/?\s*([A-Za-z][A-Za-z0-9]*)", RegexOptions.Compiled);
 
     private static Dictionary<string, int> ExtractStructuralTagCounts(string text)
     {
@@ -365,9 +348,6 @@ internal static class TranslationValidationRules
 
         foreach (Match match in StructuralHtmlTagRegex.Matches(text))
         {
-            // Key on tag name + open-vs-close so <code> and </code> are tracked
-            // separately (dropped closing tags are the common bug). <CODE> and
-            // <code> are folded since HTML tag names are case-insensitive.
             var raw = match.Value;
             var nameMatch = TagNameRegex.Match(raw);
             if (!nameMatch.Success) continue;


### PR DESCRIPTION
@teamssUTXO - opening this PR from the anti-slop pass discussion in `-5292199939` 2026-05-26. Closes 3 of the 4 gaps I surfaced when walking the existing validator infrastructure (msg 486); the 4th (broader identical-to-English check) is deliberately left for a follow-up because expanding the `ShortKeyHotspotKeys` list requires per-language maintainer judgment on which anglicisms are acceptable.

## What

### (a) HTML-tag-mismatch rule

`TranslationValidationRules.HasMatchingHtmlTags(source, translation)` compares the multiset of structural HTML tags between source and translation. Restricted to a curated allowlist of real markup elements (`strong`/`em`/`b`/`i`/`code`/`pre`/`kbd`/`a`/`span`/`p`/`div`/`br`/`ul`/`ol`/`li`/`h1-6`/`table` family/`abbr`/`del`/`ins`/`q`/`cite`/`var`/`samp`/`mark`/`small`/`sub`/`sup`/`u`) so localized example data (`<email@primer.com>`, `<John Doe>`) doesn't trip the rule. Catches the same shape today's anti-slop pass found on hindi.json (3), indonesian.json (1), and thai.json (2) - translation drops a closing `</strong>` or `</code>` pair, silently breaks UI rendering. No auto-fix path - restoring the English source would lose the translated prose around the tags.

### (d) `_maintainer` field validation

`TranslationValidationRules.IsValidMaintainerValue(value)` checks the field shape ManifestGenerator expects: `<display name or handle>|<https URL>`. Missing pipe, missing URL, or non-https URL all fail. `LanguagePackValidator` skips the `_maintainer` entry from the translation-entry pipeline (it's metadata, not a translation) and runs the shape check separately.

### (c) Wire `validate-packs` into `tests.yml` CI

New step in the existing unit-tests job runs `dotnet run -- validate-packs` after the test step, with `Translation__OutputDirectory` pointed at the repo's translations folder. Step is `continue-on-error: true` initially so the new HTML-tag rule surfaces the existing hindi/indonesian/thai issues without blocking unrelated PRs. Once those fixes land, drop `continue-on-error` to gate new slop from landing.

## Tests

5 new tests in `LanguagePackValidatorTests`:

- `ValidateAsync_FlagsHtmlTagMismatch`
- `ValidateAsync_IgnoresExampleEmailAngleBrackets`
- `ValidateAsync_FlagsInvalidMaintainerField`
- `ValidateAsync_AcceptsWellFormedMaintainerField`
- `ValidateAsync_RejectsMaintainerWithHttpScheme`

9/9 LanguagePackValidatorTests passing locally. Build clean.

## Out of scope

Item (b) - broader identical-to-English check beyond `ShortKeyHotspotKeys`. The anti-slop pass found ~30 per-language identical-to-English entries (Checkout, Downgrade, Hostname, etc.); many are acceptable anglicisms (Login, Logo, Online, Token) and which to translate is per-language maintainer judgment. Adding a generic rule risks false-positive churn. Either expand the hotspot list incrementally as patterns surface, OR add a `--strict` report-only flag in a follow-up.

## Pre-existing issues this surfaces

The `validate-packs` step (continue-on-error) will report:

- `hindi.json`: 3 HTML-tag-mismatch entries (Khush + Abhijay7 to fix)
- `indonesian.json`: 1 HTML-tag-mismatch entry (no maintainer set)
- `thai.json`: 2 HTML-tag-mismatch entries (no maintainer set)
- `romanian.json`: `Text` pre-existing hotspot-key issue

None are introduced by this PR; they were latent before. The CI step makes them visible.