### PR TITLE
Improve Japanese account menu translation

### DIFF
--- a/translations/japanese.json
+++ b/translations/japanese.json
@@ -86,7 +86,7 @@
   "Account Key": "アカウントキー",
   "Account key (xpub/tpub)": "アカウントキー (xpub/tpub)",
   "Account key path": "アカウントキーパス",
-  "Account settings and navigation moved to the top-right menu, just look up!": "アカウント設定とナビゲーションは右上のメニューに移動しました。上を見てください！",
+  "Account settings and navigation moved to the top-right menu, just look up!": "アカウント設定とナビゲーションは右上のメニューに移動しました。右上をご確認ください。",
   "Account successfully created.": "アカウントが正常に作成されました。",
   "Account successfully deleted.": "アカウントが正常に削除されました。",
   "Action canceled by user": "ユーザーによってアクションがキャンセルされました",


### PR DESCRIPTION
Improves a Japanese translation for the account settings/navigation message to sound more natural.

Before:
上を見てください！

After:
右上をご確認ください。